### PR TITLE
Addition of Async suffix to method names, for clarity

### DIFF
--- a/AsyncByDesign/Program.cs
+++ b/AsyncByDesign/Program.cs
@@ -7,8 +7,8 @@ public class Program
 		IList<string> names;
 
 		// Get the data to display
-		await Initialise();
-		names = await GetNames();
+		await InitialiseAsync();
+		names = await GetNamesAsync();
 
 		// Use the data
 		foreach (string name in names)
@@ -17,13 +17,13 @@ public class Program
 		}
 	}
 
-	private static async Task Initialise()
+	private static async Task InitialiseAsync()
 	{
 		// TODO: Do intial setup work here
 		await Task.Delay(200);
 	}
 
-	private static async Task<IList<string>> GetNames()
+	private static async Task<IList<string>> GetNamesAsync()
 	{
 		IList<string> names;
 


### PR DESCRIPTION
Adding the Async suffix to async methods provides clarity to consumers of those methods of the async design.

An Async suffix is not required, but may help with the understanding of the people who use the code - and avoid costly delays if someone misunderstands the impact of a change of a part of the system to cater for an async call during estimation.